### PR TITLE
Fix : navigation 오류 해결

### DIFF
--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, Pressable } from 'react-native';
+import { View, Text, Pressable } from 'react-native';
 import { NavigationTypes } from '../navigations/NavigationTypes';
 
 export type Message = {
   id: string;
-  policy_id?: string;
   type: 'bot' | 'user';
-  text: string;
+  policy_id?: string;
+  answer: string;
 };
 
 interface ChatBubbleProps {
@@ -20,16 +20,18 @@ export default function ChatBubble({ message, navigation }: ChatBubbleProps) {
   return (
     <Pressable
       className={`mb-2 px-4 ${isBot ? 'items-start' : 'items-end'}`}
-      onPress={() =>
-        navigation.navigate('InformScreen', { policy_id: message.id })
-      }
+      onPress={() => {
+        if (message.policy_id) {
+          navigation.navigate('InformScreen', { policy_id: message.policy_id });
+        }
+      }}
     >
       <View
         className={`max-w-[80%] rounded-xl px-4 py-3 shadow-sm ${
           isBot ? 'bg-white' : 'bg-[#D0EFFF]'
         }`}
       >
-        <Text className="text-base">{message.text}</Text>
+        <Text className="text-base">{message.answer}</Text>
       </View>
     </Pressable>
   );

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -22,12 +22,29 @@ export default function ChatScreen(props: NavigationTypes.ChatScreenProps) {
     {
       id: '1',
       type: 'bot',
-      text: '궁금한 내용이 있으면 물어보세요!\n어떤 질문이든지 대답할 준비가 됐어요 :)',
+      answer:
+        '궁금한 내용이 있으면 물어보세요!\n어떤 질문이든지 대답할 준비가 됐어요 :)',
     },
     {
       id: '2',
       type: 'bot',
-      text: '청년정책에 관한 챗봇입니다.\n어떤 내용을 도와드릴까요 ?',
+      answer: '청년정책에 관한 챗봇입니다.\n어떤 내용을 도와드릴까요 ?',
+    },
+  ];
+
+  const sampleMessages: Message[] = [
+    // api에서 받아온 메시지 예시
+    {
+      id: '3',
+      type: 'bot',
+      policy_id: '1234567',
+      answer: '서울시 청년 수당에 지원할 수 있습니다.',
+    },
+    {
+      id: '4',
+      type: 'bot',
+      policy_id: '2345678',
+      answer: '서울시 청년 창업 지원 프로그램에 참여할 수 있습니다.',
     },
   ];
 
@@ -41,7 +58,7 @@ export default function ChatScreen(props: NavigationTypes.ChatScreenProps) {
     const userMsg: Message = {
       id: Date.now().toString(),
       type: 'user',
-      text: input.trim(),
+      answer: input.trim(),
     };
 
     setMessages(prev => [...prev, userMsg]);
@@ -54,36 +71,19 @@ export default function ChatScreen(props: NavigationTypes.ChatScreenProps) {
       });
 
       const raw = res.data.answer || '';
-      const cleaned = raw.replace(/^{"answer":\s*"/, '').replace(/"}$/, '');
-      const lines = cleaned
-        .split('\\n')
-        .map((l: string) => l.trim())
-        .filter(Boolean);
 
-      const parsedMsgs: Message[] = [];
+      const botMsg: Message = {
+        id: Date.now().toString(),
+        type: 'bot',
+        answer: raw,
+      };
 
-      lines.forEach((line: string, idx: string) => {
-        const [titleRaw, descRaw] = line.split('**:').map(s => s.trim());
-
-        const title =
-          titleRaw?.replace(/^-?\s*\*\*/, '').replace(/\*\*$/, '') ?? '';
-        const desc = descRaw?.replace(/\*\*/g, '') ?? '';
-
-        const text = `${title}\n${desc}\n더보기 >`;
-
-        parsedMsgs.push({
-          id: `${Date.now()}-${idx}`,
-          type: 'bot',
-          text,
-        });
-      });
-
-      setMessages(prev => [...prev, ...parsedMsgs]);
+      setMessages(prev => [...prev, botMsg]);
     } catch (error: any) {
       const errorMsg: Message = {
         id: Date.now().toString(),
         type: 'bot',
-        text: '서버 오류로 답변을 불러오지 못했어요.',
+        answer: '서버 오류로 답변을 불러오지 못했어요.',
       };
       setMessages(prev => [...prev, errorMsg]);
     }
@@ -116,6 +116,8 @@ export default function ChatScreen(props: NavigationTypes.ChatScreenProps) {
           <>
             <ChatBubble message={initialMessages[0]} navigation={navigation} />
             <ChatBubble message={initialMessages[1]} navigation={navigation} />
+            {/* 샘플 메시지 */}
+            <ChatBubble message={sampleMessages[0]} navigation={navigation} />
           </>
         )}
         renderItem={({ item }) => (


### PR DESCRIPTION
기존 initial message 하단에 api 예시 메시지를 박아두었습니다. 
policy_id가 있는 경우에만 정책 상세 페이지로 이동 가능합니다. 
또한, 현재 api로부터 반환되는 텍스트는 raw값으로 렌더링되도록 했습니다. 
후에 api 변경에 따라 다시 구조화가 필요할듯 싶습니다~

![image](https://github.com/user-attachments/assets/302b3791-8fc6-4456-a8e8-98f392d95653)
